### PR TITLE
moved parameters to v1 structure

### DIFF
--- a/templates/v1/app-service/function/README.md
+++ b/templates/v1/app-service/function/README.md
@@ -211,10 +211,14 @@ Usage if we are using alternative resource groups for the storage account and
 
 ```powershell
 Set-AzContext -SubscriptionId SUBSCRIPTION_UUID
+Invoke-WebRequest `
+    -OutFile ($tempParamFile = New-TemporaryFile).FullName `
+    -Uri "https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/parameters/v1/common/tags/devops.json" `
+    -ErrorAction Stop
 New-AzResourceGroupDeployment `
   -Name example-deployment `
   -TemplateUri https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/templates/v1/app-service/function/template.json `
-  -TemplateParameterUri https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/parameters/common/tags/devops.json `
+  -TemplateParameterFile $tempParamFile.FullName `
   -ResourceGroupName "example-resource-group-rg" `
   -afSubscriptionId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" `
   -afName example-app-function `
@@ -230,4 +234,5 @@ New-AzResourceGroupDeployment `
   -cTag_ActivityName "Cloud Management" `
   -cTag_Environment sandbox `
   -cTag_Criticality low
+Remove-Item $tempParamFile.FullName -Force
 ```

--- a/templates/v1/app-service/plan/README.md
+++ b/templates/v1/app-service/plan/README.md
@@ -163,14 +163,19 @@ The `criticality` tag value. Has allowed values of `high`, `medium` and `low`.
 
 ```powershell
 Set-AzContext -SubscriptionId SUBSCRIPTION_UUID
+Invoke-WebRequest `
+    -OutFile ($tempParamFile = New-TemporaryFile).FullName `
+    -Uri "https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/parameters/v1/common/tags/devops.json" `
+    -ErrorAction Stop
 New-AzResourceGroupDeployment `
   -Name example-deployment `
   -TemplateUri https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/templates/v1/app-service/plan/template.json `
-  -TemplateParameterUri https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/parameters/common/tags/devops.json `
+  -TemplateParameterFile $tempParamFile.FullName `
   -ResourceGroupName "example-resource-group-rg" `
   -aspName example-app-service-plan `
   -aspLocation uksouth `
   -cTag_ActivityName "Cloud Management" `
   -cTag_Environment sandbox `
   -cTag_Criticality low
+Remove-Item $tempParamFile.FullName -Force
 ```

--- a/templates/v1/application-insights/README.md
+++ b/templates/v1/application-insights/README.md
@@ -109,14 +109,19 @@ The `criticality` tag value. Has allowed values of `high`, `medium` and `low`.
 
 ```powershell
 Set-AzContext -SubscriptionId SUBSCRIPTION_UUID
+Invoke-WebRequest `
+    -OutFile ($tempParamFile = New-TemporaryFile).FullName `
+    -Uri "https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/parameters/v1/common/tags/devops.json" `
+    -ErrorAction Stop
 New-AzResourceGroupDeployment `
   -Name example-deployment `
   -TemplateUri https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/templates/v1/application-insights/template.json `
-  -TemplateParameterUri https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/parameters/common/tags/devops.json `
+  -TemplateParameterFile $tempParamFile.FullName `
   -ResourceGroupName "example-resource-group-rg" `
   -aiName example-application-insight `
   -aiLocation uksouth `
   -cTag_ActivityName "Cloud Management" `
   -cTag_Environment sandbox `
   -cTag_Criticality low
+Remove-Item $tempParamFile.FullName -Force
 ```

--- a/templates/v1/key-vault/README.md
+++ b/templates/v1/key-vault/README.md
@@ -130,15 +130,20 @@ The `criticality` tag value. Has allowed values of `high`, `medium` and `low`.
 
 ```powershell
 Set-AzContext -SubscriptionId SUBSCRIPTION_UUID
+Invoke-WebRequest `
+    -OutFile ($tempParamFile = New-TemporaryFile).FullName `
+    -Uri "https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/parameters/v1/common/tags/devops.json" `
+    -ErrorAction Stop
 New-AzDeployment `
   -Name example-deployment `
   -Location uksouth `
   -TemplateUri https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/templates/v1/key-vault/template.json `
-  -TemplateParameterUri https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/parameters/common/tags/devops.json `
+  -TemplateParameterFile $tempParamFile.FullName `
   -kvName unique-key-vault-name-here `
   -kvLocation uksouth `
   -kvTenant xxx `
   -cTag_ActivityName "Cloud Management" `
   -cTag_Environment sandbox `
   -cTag_Criticality low
+Remove-Item $tempParamFile.FullName -Force
 ```

--- a/templates/v1/resource-group/README.md
+++ b/templates/v1/resource-group/README.md
@@ -100,14 +100,19 @@ The `criticality` tag value. Has allowed values of `high`, `medium` and `low`.
 
 ```powershell
 Set-AzContext -SubscriptionId SUBSCRIPTION_UUID
+Invoke-WebRequest `
+    -OutFile ($tempParamFile = New-TemporaryFile).FullName `
+    -Uri "https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/parameters/common/v1/tags/devops.json" `
+    -ErrorAction Stop
 New-AzDeployment `
   -Name example-deployment `
   -Location uksouth `
   -TemplateUri https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/templates/v1/resource-group/template.json `
-  -TemplateParameterUri https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/parameters/common/tags/devops.json `
+  -TemplateParameterFile $tempParamFile.FullName `
   -rgName example-resource-group `
   -rgLocation uksouth `
   -cTag_ActivityName "Cloud Management" `
   -cTag_Environment sandbox `
   -cTag_Criticality low
+Remove-Item $tempParamFile.FullName -Force
 ```

--- a/templates/v1/storage-account/README.md
+++ b/templates/v1/storage-account/README.md
@@ -142,14 +142,19 @@ The `criticality` tag value. Has allowed values of `high`, `medium` and `low`.
 
 ```powershell
 Set-AzContext -SubscriptionId SUBSCRIPTION_UUID
+Invoke-WebRequest `
+    -OutFile ($tempParamFile = New-TemporaryFile).FullName `
+    -Uri "https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/parameters/v1/common/tags/devops.json" `
+    -ErrorAction Stop
 New-AzResourceGroupDeployment `
   -Name example-deployment `
   -TemplateUri https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/templates/v1/storage-account/template.json `
-  -TemplateParameterUri https://raw.githubusercontent.com/hmcts/ops-arm-templates/master/parameters/common/tags/devops.json `
+  -TemplateParameterFile $tempParamFile.FullName `
   -ResourceGroupName "example-resource-group-rg" `
   -saName random-string-here `
   -saLocation uksouth `
   -cTag_ActivityName "Cloud Management" `
   -cTag_Environment sandbox `
   -cTag_Criticality low
+Remove-Item $tempParamFile.FullName -Force
 ```


### PR DESCRIPTION
due to issues with using remote URI for the parameters file (see
https://docs.microsoft.com/en-gb/azure/azure-resource-manager/resource-manager-parameter-files#parameter-precedence)
this PR changes the various README files to show a mechanism to
use the local file instead (which allows inline overrides)

also changed the structure to use a v1/ base folder which follows
the main templates structure.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
